### PR TITLE
Set picker cell font

### DIFF
--- a/PPJEmailPicker/PPJEmailPicker.m
+++ b/PPJEmailPicker/PPJEmailPicker.m
@@ -387,6 +387,7 @@
 		cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellIdentifier];
 	}
 	cell.textLabel.text = self.possibleStringsFiltered[indexPath.row];
+    cell.textLabel.font = self.autoCompleteTextFont;
 	cell.textLabel.textColor = self.autoCompleteTableCellTextColor;
 	cell.backgroundColor = self.autoCompleteTableCellBackgroundColor;
 	return cell;


### PR DESCRIPTION
This PR is intended for setting email picker label cell font same as `autoCompleteTextFont`